### PR TITLE
fix/rules-required

### DIFF
--- a/packages/vuetify/src/labs/rules/rules.ts
+++ b/packages/vuetify/src/labs/rules/rules.ts
@@ -39,10 +39,8 @@ export function createRules (options: RulesOptions | undefined, locale: LocaleIn
     aliases: {
       required: (err?: string) => {
         (v: any) => {
-          if (typeof v === 'number') {
-            return !!v.toString() || t(err || '$vuetify.rules.required')
-          }
-          return !!v || t(err || '$vuetify.rules.required')
+          // If the modifier .number is used, the 0 will be a number and it's a falsy value so we need to check for it
+          return v === 0 || !!v || t(err || '$vuetify.rules.required')
         }
       },
       email: (err?: string) => {

--- a/packages/vuetify/src/labs/rules/rules.ts
+++ b/packages/vuetify/src/labs/rules/rules.ts
@@ -38,7 +38,12 @@ export function createRules (options: RulesOptions | undefined, locale: LocaleIn
   return mergeDeep({
     aliases: {
       required: (err?: string) => {
-        return (v: any) => !!v || t(err || '$vuetify.rules.required')
+        (v: any) => {
+          if (typeof v === 'number') {
+            return !!v.toString() || t(err || '$vuetify.rules.required')
+          }
+          return !!v || t(err || '$vuetify.rules.required')
+        }
       },
       email: (err?: string) => {
         return (v: any) => (!v || (typeof v === 'string' && /^.+@\S+\.\S+$/.test(v))) || t(err || '$vuetify.rules.email')


### PR DESCRIPTION
If we use the modifier .number in a v-textfield for example with the number 0, the rules return false.
